### PR TITLE
修复request()->getQueryString()没有返回值的问题

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -46,6 +46,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request
         $server['PHP_SELF']='laraman';
         $server['REQUEST_TIME_FLOAT']=microtime(true);
         $server['REQUEST_TIME']=time();
+        $server['QUERY_STRING']=$workmanRequest->queryString();
         return $server;
     }
 


### PR DESCRIPTION
缺失$server['QUERY_STRING']会导致request()->getQueryString()返回永远是空,
因而引发Dcat Admin中QuickSearch类action的url不正确,
导致LazyRenderable窗口中的搜索功能失效报错.